### PR TITLE
Change convertPhpToXml() for DateTimeTypeConverter and DateTypeConverter

### DIFF
--- a/src/Phpro/SoapClient/Soap/TypeConverter/DateTimeTypeConverter.php
+++ b/src/Phpro/SoapClient/Soap/TypeConverter/DateTimeTypeConverter.php
@@ -54,6 +54,6 @@ class DateTimeTypeConverter implements TypeConverterInterface
      */
     public function convertPhpToXml($php): string
     {
-        return sprintf('<%1$s>%2$s</%1$s>', $this->getTypeName(), $php->format('Y-m-d\TH:i:sP'));
+        return $php !== null ? sprintf('<%1$s>%2$s</%1$s>', $this->getTypeName(), $php->format('Y-m-d\TH:i:sP')) : '';
     }
 }

--- a/src/Phpro/SoapClient/Soap/TypeConverter/DateTypeConverter.php
+++ b/src/Phpro/SoapClient/Soap/TypeConverter/DateTypeConverter.php
@@ -52,6 +52,6 @@ class DateTypeConverter implements TypeConverterInterface
      */
     public function convertPhpToXml($php): string
     {
-        return sprintf('<%1$s>%2$s</%1$s>', $this->getTypeName(), $php->format('Y-m-d'));
+        return $php !== null ? sprintf('<%1$s>%2$s</%1$s>', $this->getTypeName(), $php->format('Y-m-d')) : '';
     }
 }


### PR DESCRIPTION
If a Date(Time) element is optional and no value (NULL) is assigned to it,
the former implementation still expected to get some valid DateTime Object
that could be converted and failed on that.
This was changed to return an empty string when the input is equal to NULL.